### PR TITLE
Patch 1

### DIFF
--- a/sinusbot/sinusbot.xml
+++ b/sinusbot/sinusbot.xml
@@ -32,5 +32,7 @@ Password: (your password from WEB UI Password)</Overview>
   <Config Name="WEB UI" Target="8087" Default="8087" Mode="tcp" Description="Port for WEB UI" Type="Port" Display="always" Required="true" Mask="false">8087</Config>
   <Config Name="Scripts Path" Target="/opt/sinusbot/scripts" Default="/mnt/user/appdata/sinusbot/scripts" Mode="rw" Description="Data Path for the Sinusbot Scripts" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/sinusbot/scripts</Config>
   <Config Name="Data Path" Target="/opt/sinusbot/data" Default="/mnt/user/appdata/sinusbot/data" Mode="rw" Description="Sinusbot Data Path. Where Sinusbot can Store Data" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/sinusbot/data</Config>
+  <Config Name="UID" Target="UID" Default="1000" Mode="" Description="" Type="Variable" Display="always" Required="false" Mask="false">1000</Config>
+  <Config Name="GID" Target="GID" Default="1000" Mode="" Description="" Type="Variable" Display="always" Required="false" Mask="false">1000</Config>
   <Config Name="WEB UI Password" Target="OVERRIDE_PASSWORD" Default="foobar" Mode="" Description="" Type="Variable" Display="always" Required="false" Mask="true">foobar</Config>
 </Container>

--- a/sinusbot/sinusbot.xml
+++ b/sinusbot/sinusbot.xml
@@ -32,7 +32,7 @@ Password: (your password from WEB UI Password)</Overview>
   <Config Name="WEB UI" Target="8087" Default="8087" Mode="tcp" Description="Port for WEB UI" Type="Port" Display="always" Required="true" Mask="false">8087</Config>
   <Config Name="Scripts Path" Target="/opt/sinusbot/scripts" Default="/mnt/user/appdata/sinusbot/scripts" Mode="rw" Description="Data Path for the Sinusbot Scripts" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/sinusbot/scripts</Config>
   <Config Name="Data Path" Target="/opt/sinusbot/data" Default="/mnt/user/appdata/sinusbot/data" Mode="rw" Description="Sinusbot Data Path. Where Sinusbot can Store Data" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/sinusbot/data</Config>
-  <Config Name="UID" Target="UID" Default="1000" Mode="" Description="" Type="Variable" Display="always" Required="false" Mask="false">1000</Config>
-  <Config Name="GID" Target="GID" Default="1000" Mode="" Description="" Type="Variable" Display="always" Required="false" Mask="false">1000</Config>
+  <Config Name="UID" Target="UID" Default="1000" Mode="" Description="User Identifier" Type="Variable" Display="always" Required="false" Mask="false">1000</Config>
+  <Config Name="GID" Target="GID" Default="1000" Mode="" Description="Group Identifier" Type="Variable" Display="always" Required="false" Mask="false">1000</Config>
   <Config Name="WEB UI Password" Target="OVERRIDE_PASSWORD" Default="foobar" Mode="" Description="" Type="Variable" Display="always" Required="false" Mask="true">foobar</Config>
 </Container>


### PR DESCRIPTION
It is recommended that you run the SinusBot as a non-root user, even though the docker container is mostly isolated from the host. This can be done as described in the following:

add a new user:

useradd --no-create-home -s /sbin/nologin -U sinusbot

create the required folders if they don't exist:

mkdir -p /opt/sinusbot/data /opt/sinusbot/scripts

give the user permissions to the folders:

chown -R sinusbot:sinusbot /opt/sinusbot

Run the docker image with the UID and GID environment variables set to the correct user- and group-ID as shown below:

docker run -d -p 8087:8087 \
           -v /opt/sinusbot/scripts:/opt/sinusbot/scripts \
           -v /opt/sinusbot/data:/opt/sinusbot/data \
           -e UID=$(id -u sinusbot) \
           -e GID=$(id -g sinusbot) \
           --name sinusbot \
           sinusbot/docker